### PR TITLE
Support decimal numeric pg data type

### DIFF
--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -142,6 +142,7 @@ module.exports = class extends Generator {
       if (pgType.startsWith('character')) return 'String';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'Integer';
       if (['float', 'double precision'].includes(pgType)) return 'Float';
+      if (['decimal', 'numeric'].includes(pgType)) return 'Numeric';
       if (pgType === 'bigint') return 'BigInteger';
       if (pgType === 'boolean') return 'Boolean';
       if (pgType === 'date') return 'Date';
@@ -153,7 +154,8 @@ module.exports = class extends Generator {
       if (pgType === 'text') return 'str';
       if (pgType.startsWith('character')) return 'str';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'int';
-      if (['float', 'double precision'].includes(pgType)) return 'float';
+      if (['float', 'double precision', 'decimal', 'numeric'].includes(pgType))
+        return 'float';
       if (pgType === 'bigint') return 'int';
       if (pgType === 'boolean') return 'bool';
       if (pgType === 'date') return 'date';
@@ -165,7 +167,8 @@ module.exports = class extends Generator {
       if (pgType === 'text') return 'string';
       if (pgType.startsWith('character')) return 'string';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'int';
-      if (['float', 'double precision'].includes(pgType)) return 'float';
+      if (['float', 'double precision', 'decimal', 'numeric'].includes(pgType))
+        return 'float';
       if (pgType === 'bigint') return 'int64';
       if (pgType === 'boolean') return 'boolean';
       if (pgType === 'date') return 'date';

--- a/generators/crud/index.js
+++ b/generators/crud/index.js
@@ -142,7 +142,7 @@ module.exports = class extends Generator {
       if (pgType.startsWith('character')) return 'String';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'Integer';
       if (['float', 'double precision'].includes(pgType)) return 'Float';
-      if (['decimal', 'numeric'].includes(pgType)) return 'Numeric';
+      if (pgType === 'decimal' || pgType.startsWith('numeric')) return 'Numeric';
       if (pgType === 'bigint') return 'BigInteger';
       if (pgType === 'boolean') return 'Boolean';
       if (pgType === 'date') return 'Date';
@@ -154,7 +154,10 @@ module.exports = class extends Generator {
       if (pgType === 'text') return 'str';
       if (pgType.startsWith('character')) return 'str';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'int';
-      if (['float', 'double precision', 'decimal', 'numeric'].includes(pgType))
+      if (
+        ['float', 'double precision', 'decimal'].includes(pgType) ||
+        pgType.startsWith('numeric')
+      )
         return 'float';
       if (pgType === 'bigint') return 'int';
       if (pgType === 'boolean') return 'bool';
@@ -167,7 +170,10 @@ module.exports = class extends Generator {
       if (pgType === 'text') return 'string';
       if (pgType.startsWith('character')) return 'string';
       if (['int', 'integer', 'smallint'].includes(pgType)) return 'int';
-      if (['float', 'double precision', 'decimal', 'numeric'].includes(pgType))
+      if (
+        ['float', 'double precision', 'decimal'].includes(pgType) ||
+        pgType.startsWith('numeric')
+      )
         return 'float';
       if (pgType === 'bigint') return 'int64';
       if (pgType === 'boolean') return 'boolean';


### PR DESCRIPTION
Add types decimal and numeric in the mapping process for SQLAlchemy, Python, and Swagger.

Issue #13 